### PR TITLE
商品詳細ページの実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,7 @@
 class ItemsController < ApplicationController
 
+  before_action :set_item, only: [:show, :edit]
+
   def index
     @item = Item.all
   end
@@ -16,6 +18,11 @@ class ItemsController < ApplicationController
   end
 
   def edit
+  end
+
+  private
+  def set_item
+    @item = Item.find(params[:id])
   end
   
 end

--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -1,2 +1,7 @@
 module ItemsHelper
+
+  def converting_to_jpy(price)
+    "¥#{price.to_s(:delimited, delimiter: ',')}"
+  end
+
 end

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -157,8 +157,7 @@
           に同意したことになります。
 
         /出品
-        /= f.submit "出品する", items_path, method: 'post', class: 'red-btn'
-
+        = f.submit "出品する", items_path, method: 'post', class: 'red-btn'
         = link_to root_path, class: 'sell-return-btn' do
           もどる
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -5,7 +5,7 @@
   .item__page  
     .item__page__title
       .item__page__title__name
-        ダンベル
+        = @item.name
     .item__page__data
       .item__page__data__photo-box
         .item__page__data__photo-box__photo
@@ -58,14 +58,14 @@
 
     .item__page__price
       .item__page__price__number
-        ¥100,000
+        = converting_to_jpy(@item.price)
       .item__page__price__tax
         (税込)
       .item__page__price__postage
         送料込み
     = link_to "購入画面に進む", edit_item_path, class: "item__page__buy"
     .item__page__text
-      商品を見て頂きありがとうございます！
+      = @item.description
     .item__page__button
       .item__page__button__left
         %button.item__page__button__left__like{type: "button"}


### PR DESCRIPTION
# What
商品の詳細ページに、商品名、価格、テキスト(description)の表示。

items/show.html.haml
item_helper.rbに記述(¥10,000のように表示させる)

# Why
商品を選択した際に商品詳細画面に表示させる為。

https://gyazo.com/460dd0594abb20ea583b0de3f3db4b37

